### PR TITLE
Eliminate redundant WETH conversion

### DIFF
--- a/pages/dustzap/index.jsx
+++ b/pages/dustzap/index.jsx
@@ -96,7 +96,7 @@ const getPlatformFeeTxns = (chainMetadata, platformFee, referrer) => {
   const wrapEthTxn = prepareContractCall({
     contract: wethContract,
     method: "deposit",
-    value: toWei(ethers.utils.formatEther(platformFee)),
+    value: platformFee,
   });
   txns.push(wrapEthTxn);
 


### PR DESCRIPTION
## Description

Removed an unnecessary round-trip conversion of `platformFee` from Wei to Ether and back to Wei in the WETH deposit transaction. `platformFee` is already a BigNumber in Wei, and the previous conversion introduced potential precision loss.

This change directly uses `platformFee` as the value, which is already in the correct Wei format for `prepareContractCall`.

## Checklist:

- [ ] Add test cases to all the changes you introduce
- [ ] Update the documentation if necessary
- [ ] Update ENV on fleek if necessary
- [ ] Use $1 to test the entire pipeline